### PR TITLE
Use unique titles for all schema JSON files

### DIFF
--- a/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.schema.json
+++ b/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_collision_shapes glTF extension",
+    "title": "KHR_collision_shapes glTF Document Extension",
     "type": "object",
     "description": "Top level collision primitives.",
     "allOf": [ { "$ref" : "glTFProperty.schema.json" } ],
@@ -16,8 +16,8 @@
         },
         "extensions": { },
         "extras": { }
-     },
-     "required": [
-         "shapes"
-     ]
+    },
+    "required": [
+        "shapes"
+    ]
 }

--- a/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.shape.box.schema.json
+++ b/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.shape.box.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_collision_shapes glTF extension",
+    "title": "KHR_collision_shapes Box Shape",
     "type": "object",
     "description": "Parameters describing a box shape.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.shape.capsule.schema.json
+++ b/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.shape.capsule.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_collision_shapes glTF extension",
+    "title": "KHR_collision_shapes Capsule Shape",
     "type": "object",
     "description": "Parameters describing a capsule shape.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.shape.convex.schema.json
+++ b/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.shape.convex.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_collision_shapes glTF extension",
+    "title": "KHR_collision_shapes Convex Shape",
     "type": "object",
     "description": "Parameters describing a convex shape.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.shape.cylinder.schema.json
+++ b/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.shape.cylinder.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_collision_shapes glTF extension",
+    "title": "KHR_collision_shapes Cylinder Shape",
     "type": "object",
     "description": "Parameters describing a cylinder shape.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.shape.schema.json
+++ b/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.shape.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_collision_shapes glTF extension",
+    "title": "KHR_collision_shapes Shape Resource",
     "type": "object",
     "description": "Parameters describing a node's physics collision geometry.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],
@@ -108,5 +108,7 @@
             "required": ["trimesh"]
         }
     ],
-    "required": "type"
+    "required": [
+        "type"
+    ]
 }

--- a/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.shape.sphere.schema.json
+++ b/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.shape.sphere.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_collision_shapes glTF extension",
+    "title": "KHR_collision_shapes Sphere Shape",
     "type": "object",
     "description": "Parameters describing a sphere shape.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.shape.trimesh.schema.json
+++ b/extensions/2.0/Khronos/KHR_collision_shapes/schema/glTF.KHR_collision_shapes.shape.trimesh.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_collision_shapes glTF extension",
+    "title": "KHR_collision_shapes Trimesh Shape",
     "type": "object",
     "description": "Parameters describing a mesh shape.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_rigid_bodies/README.md
+++ b/extensions/2.0/Khronos/KHR_rigid_bodies/README.md
@@ -1,10 +1,11 @@
-# KHR\_rigid\_bodies
+# KHR_rigid_bodies
 
 ## Contributors
 
 * Rory Mullane, Microsoft, <mailto:romul@microsoft.com>
 * Eoin McLoughlin, Microsoft, <mailto:eomcl@microsoft.com>
 * George Tian, Microsoft, <mailto:geotian@microsoft.com>
+* Aaron Franke, Godot Engine, <mailto:arnfranke@yahoo.com>
 
 ## Status
 
@@ -72,7 +73,7 @@ Rigid body motions have the following properties:
 
 ### Colliders
 
-To specify the geometry used to perform collision detection, we use the KHR\_collision\_shapes extension. To add collision geometry and enable a node to generate impulses from collision detection, a node's `collider` property is used. This property supplies three fields; the `collider` property indexes into the set of top level collision shapes and describes the collision volume used by that node, while the `physicsMaterial` indexes into the top level set of physics materials (see the "Collision Response" section of this document) and the `collisionFilter` indexes into the top level set of collision filters (see the "Collision Filtering" section of this document).
+To specify the geometry used to perform collision detection, we use the `KHR_collision_shapes` extension. To add collision geometry and enable a node to generate impulses from collision detection, a node's `collider` property is used. This property supplies three fields; the `collider` property indexes into the set of top level collision shapes and describes the collision volume used by that node, while the `physicsMaterial` indexes into the top level set of physics materials (see the "Collision Response" section of this document) and the `collisionFilter` indexes into the top level set of collision filters (see the "Collision Filtering" section of this document).
 
 | |Type|Description|
 |-|-|-|
@@ -131,7 +132,7 @@ Note, that this can generate asymmetric states - `A` might determine that it _do
 
 A useful construct in a physics engine is a collision volume which does not generate impulses when overlapping with other volumes - implementations may use this behavior to generate events, which can implement application-specific logic; such objects are typically called "triggers", "phantoms", "sensors", or "overlap volumes" in physics simulation engines.
 
-A node may have a `trigger` property set; this is similar to the `collider` in that it references a collision volume defined by the KHR\_collision\_shapes extension but lacks a physics material. It does, however, provide a collision filter with the same semantics as the `collider`.
+A node may have a `trigger` property set; this is similar to the `collider` in that it references a collision volume defined by the `KHR_collision_shapes` extension but lacks a physics material. It does, however, provide a collision filter with the same semantics as the `collider`.
 
 Describing the precise mechanism by which overlap events are generated and what occurs as a result is beyond the scope of this specification; simulation software will typically output overlap begin/end events as an output from the simulation step, which is hooked into application-specific business logic.
 

--- a/extensions/2.0/Khronos/KHR_rigid_bodies/schema/glTF.KHR_rigid_bodies.collision_filter.schema.json
+++ b/extensions/2.0/Khronos/KHR_rigid_bodies/schema/glTF.KHR_rigid_bodies.collision_filter.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_rigid_bodies glTF extension",
+    "title": "KHR_rigid_bodies Collision Filter",
     "type": "object",
     "description": "Parameters describing a parameterization of a collision filter, allowing for disabling collision between pairs of shapes.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_rigid_bodies/schema/glTF.KHR_rigid_bodies.joint.schema.json
+++ b/extensions/2.0/Khronos/KHR_rigid_bodies/schema/glTF.KHR_rigid_bodies.joint.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_rigid_bodies glTF extension",
+    "title": "KHR_rigid_bodies Physics Joint",
     "type": "object",
     "description": "Parameters describing a set of joint limits, constraining the motion of a pair of bodies.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_rigid_bodies/schema/glTF.KHR_rigid_bodies.joint_limit.schema.json
+++ b/extensions/2.0/Khronos/KHR_rigid_bodies/schema/glTF.KHR_rigid_bodies.joint_limit.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_rigid_bodies glTF extension",
+    "title": "KHR_rigid_bodies Physics Joint Limit",
     "type": "object",
     "description": "Parameters describing how the relative motion of a pair of nodes is constrained.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_rigid_bodies/schema/glTF.KHR_rigid_bodies.material.schema.json
+++ b/extensions/2.0/Khronos/KHR_rigid_bodies/schema/glTF.KHR_rigid_bodies.material.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_rigid_bodies glTF extension",
+    "title": "KHR_rigid_bodies Physics Material",
     "type": "object",
     "description": "Parameters describing how an object should respond to collisions during physics simulation.",
     "allOf": [ { "$ref": "glTFChildOfRootProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_rigid_bodies/schema/glTF.KHR_rigid_bodies.schema.json
+++ b/extensions/2.0/Khronos/KHR_rigid_bodies/schema/glTF.KHR_rigid_bodies.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_rigid_bodies glTF extension",
+    "title": "KHR_rigid_bodies glTF Document Extension",
     "type": "object",
     "description": "Top level physics properties.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_rigid_bodies/schema/node.KHR_rigid_bodies.collider.json
+++ b/extensions/2.0/Khronos/KHR_rigid_bodies/schema/node.KHR_rigid_bodies.collider.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_rigid_bodies glTF extension",
+    "title": "KHR_rigid_bodies Node Collider Property",
     "type": "object",
     "description": "Parameters describing a shape used for collison detection and response.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_rigid_bodies/schema/node.KHR_rigid_bodies.joint.schema.json
+++ b/extensions/2.0/Khronos/KHR_rigid_bodies/schema/node.KHR_rigid_bodies.joint.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_rigid_bodies glTF extension",
+    "title": "KHR_rigid_bodies Node Joint Property",
     "type": "object",
     "description": "Parameters describing how the relative motion of a pair of nodes is constrained.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_rigid_bodies/schema/node.KHR_rigid_bodies.motion.schema.json
+++ b/extensions/2.0/Khronos/KHR_rigid_bodies/schema/node.KHR_rigid_bodies.motion.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_rigid_bodies glTF extension",
+    "title": "KHR_rigid_bodies Node Motion Property",
     "type": "object",
     "description": "Parameters describing how a node's transform should be driven by physics simulation.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_rigid_bodies/schema/node.KHR_rigid_bodies.schema.json
+++ b/extensions/2.0/Khronos/KHR_rigid_bodies/schema/node.KHR_rigid_bodies.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_rigid_bodies glTF extension",
+    "title": "KHR_rigid_bodies glTF Node Extension",
     "type": "object",
     "description": "Physics properties for a node.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],

--- a/extensions/2.0/Khronos/KHR_rigid_bodies/schema/node.KHR_rigid_bodies.trigger.schema.json
+++ b/extensions/2.0/Khronos/KHR_rigid_bodies/schema/node.KHR_rigid_bodies.trigger.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "KHR_rigid_bodies glTF extension",
+    "title": "KHR_rigid_bodies Node Trigger Property",
     "type": "object",
     "description": "Parameters describing a volume used for collison detection, but does not cause a collision response.",
     "allOf": [ { "$ref": "glTFProperty.schema.json" } ],


### PR DESCRIPTION
This PR ensures all JSON schemas have unique names. I also included a few other fixes:

* Use the term "resource" to describe the `MSFT_collision_primitives.collider` data structure.
* Fix some cases of extension names not being `code` in the README.md files.
* Fix invalid `"required"` field in `MSFT_collision_primitives.collider` schema.
* Fix indentation in `MSFT_collision_primitives` schema.

Note: I skipped `glTF.MSFT_rigid_bodies.joint.schema.json` to avoid conflicts when #21 is fixed.